### PR TITLE
Fix lint errors and update molecule for ansible v2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ services:
 before_install:
   - sudo apt-get -qq update
 install:
-  - pip install molecule==2.22rc1 
-  - pip install flake8
-  - pip install cerberus==1.3.1
+  # Need to use the latest molecule 2.22 rc, for compatibility with ansible 2.8.x (provided in the used docker image)
+  - pip install molecule==2.22rc3
   - pip install docker
 script:
   - molecule test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - sudo apt-get -qq update
 install:
   - pip install molecule==2.22rc1 
+  - pip install flake8
   - pip install cerberus==1.3.1
   - pip install docker
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ services:
 before_install:
   - sudo apt-get -qq update
 install:
-  # Need to use the latest molecule 2.22 rc, for compatibility with ansible 2.8.x (provided in the used docker image)
-  - pip install molecule==2.22rc3
+  # molecule version >v2.22 required for compatibility with ansible 2.8.x (provided in the used docker image)
+  - pip install molecule==2.22
   - pip install docker
 script:
   - molecule test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ services:
 before_install:
   - sudo apt-get -qq update
 install:
-  - pip install molecule
+  - pip install molecule==22rc1 
+  - pip install cerberus==1.3.1
   - pip install docker
 script:
   - molecule test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 before_install:
   - sudo apt-get -qq update
 install:
-  - pip install molecule==22rc1 
+  - pip install molecule==2.22rc1 
   - pip install cerberus==1.3.1
   - pip install docker
 script:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 galaxy_info:
   author: "Matthias Baumann & Jan Hentschel"
+  description: "Role to install kerberos server(s)"
   company: Ultra Tendency GmbH
   license: BSD 3-Clause
   min_ansible_version: 1.4
@@ -8,7 +9,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
-  categories:
+  galaxy_tags:
     - kerberos
     - kdc
-dependencies: []
+dependencies: [ ]

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ lint:
 platforms:
   - name: centos-7
     image: fiercely/centos7:systemd
-    privileged: True
+    privileged: true
     volume_mounts:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/usr/sbin/init"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -25,7 +25,7 @@ def test_kdc_conf(host):
     assert kdc_conf.is_file
     assert kdc_conf.user == 'root'
     assert kdc_conf.group == 'root'
-    assert oct(kdc_conf.mode) == '0600'
+    assert oct(kdc_conf.mode) == '0o600'
 
 
 @pytest.mark.parametrize('content', [
@@ -50,7 +50,7 @@ def test_kadm5_acl(host):
     assert kadm5_acl.is_file
     assert kadm5_acl.user == 'root'
     assert kadm5_acl.group == 'root'
-    assert oct(kadm5_acl.mode) == '0600'
+    assert oct(kadm5_acl.mode) == '0o600'
 
 
 @pytest.mark.parametrize('content', [
@@ -70,7 +70,7 @@ def test_krb5_conf(host):
     assert krb5_conf.is_file
     assert krb5_conf.user == 'root'
     assert krb5_conf.group == 'root'
-    assert oct(krb5_conf.mode) == '0644'
+    assert oct(krb5_conf.mode) == '0o644'
 
 
 @pytest.mark.parametrize('content', [

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -25,7 +25,7 @@ def test_kdc_conf(host):
     assert kdc_conf.is_file
     assert kdc_conf.user == 'root'
     assert kdc_conf.group == 'root'
-    assert oct(kdc_conf.mode) == '0o600'
+    assert kdc_conf.mode == 0o600
 
 
 @pytest.mark.parametrize('content', [
@@ -50,7 +50,7 @@ def test_kadm5_acl(host):
     assert kadm5_acl.is_file
     assert kadm5_acl.user == 'root'
     assert kadm5_acl.group == 'root'
-    assert oct(kadm5_acl.mode) == '0o600'
+    assert kadm5_acl.mode == 0o600
 
 
 @pytest.mark.parametrize('content', [
@@ -70,7 +70,7 @@ def test_krb5_conf(host):
     assert krb5_conf.is_file
     assert krb5_conf.user == 'root'
     assert krb5_conf.group == 'root'
-    assert oct(krb5_conf.mode) == '0o644'
+    assert krb5_conf.mode == 0o644
 
 
 @pytest.mark.parametrize('content', [

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -4,9 +4,8 @@
 
 - name: Install the kerberos packages
   yum:
-    name: "{{ item }}"
+    name: "{{ kerberos_server_redhat_pkg }}"
     state: present
-  with_items: "{{ kerberos_server_redhat_pkg }}"
 
 - name: Copy the KDC configuration file
   template:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -29,6 +29,7 @@
 
 - name: Create the initial Kerberos database
   shell: >
+    set -o pipefail;
     echo -e "{{ kerberos_server_master_db_pass }}\n{{ kerberos_server_master_db_pass }}" | kdb5_util create -s;
     touch /var/kerberos/db_created creates=/var/kerberos/db_created
 
@@ -41,6 +42,7 @@
 
 - name: Create an admin user for administering the Kerberos database
   shell: >
+    set -o pipefail;
     echo -e "{{ kerberos_server_kadmin_pass }}\n{{ kerberos_server_kadmin_pass }}" |
     kadmin.local  -q "addprinc {{ kerberos_server_kadmin_user }}/admin";
     touch /var/kerberos/admin_created creates=/var/kerberos/admin_created


### PR DESCRIPTION
Changes proposed in this pull request:
* Fixes all yaml lint and ansible lint errors that appeared due to recent ansible-lint module updates
* also had to update to the latest molecule version, for compatibility with ansible v2.8.x (which got used automatically by using recent docker containers, at least in my kdc-with-replica tests, see upcoming PR)
* The explicit install of `cerberus v1.3.1`, indeed required (to fix some schema error), can be removed once we have a molecule release that contains the fix from https://github.com/ansible/molecule/pull/2103 (merged to master since the 17.06.2019)

Full credits go to @NadOby, who initially contributed these fixes to a PR in our repo (
 https://github.com/scigility/kerberos_server/pull/1), which I had to rebase, because it was derived from an unfinished branch

